### PR TITLE
Fix argv for uploads:downsize task

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1097,7 +1097,7 @@ task "uploads:downsize" => :environment do
   default_image_pixels = 1_000_000 # 1 megapixel
 
   max_image_pixels = [
-    ARGV[0]&.to_i || default_image_pixels,
+    ARGV[1]&.to_i || default_image_pixels,
     min_image_pixels
   ].max
 


### PR DESCRIPTION
uploads:downsize reads a ARGV for a minimum size, so this fixes the arg index

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
